### PR TITLE
Change location.alt field type interger->number

### DIFF
--- a/nodelist-schema-1.0.1.json
+++ b/nodelist-schema-1.0.1.json
@@ -6,8 +6,8 @@
   "properties": {
     "version": {
       "type": "string",
-      "enum" : ["1.0.1"],
-      "default" : "1.0.1",
+      "enum" : ["1.0.2"],
+      "default" : "1.0.2",
       "required" : true
  	},
     "updated_at": {
@@ -89,7 +89,7 @@
                 "type": "number"
               },
               "alt": {
-                "type": "integer"
+                "type": "number"
               }
             }
           }


### PR DESCRIPTION
This is a backwards compatible change, hence upping the version to 1.0.2 should be alright (according to #semver 1.1 would also be possible, but I think this is more of a bugfix, why would altitude be restricted to integers...)
