### PR TITLE
Fixed invalid JSON Schema Draft 4

### DIFF
--- a/nodelist-schema-1.0.1.json
+++ b/nodelist-schema-1.0.1.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-03/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "nodelistjson schema",
   "type": "object",
   "required" : ["version"],
@@ -7,8 +7,7 @@
     "version": {
       "type": "string",
       "enum" : ["1.0.1"],
-      "default" : "1.0.1",
-      "required" : true
+      "default" : "1.0.1"
     },
     "updated_at": {
       "type": "string"

--- a/nodelist-schema-1.0.1.json
+++ b/nodelist-schema-1.0.1.json
@@ -9,7 +9,7 @@
       "enum" : ["1.0.1"],
       "default" : "1.0.1",
       "required" : true
- 	},
+    },
     "updated_at": {
       "type": "string"
     },


### PR DESCRIPTION
The current nodelist-schema-1.0.1.json is neither a valid JSON Schema Draft 3 nor a a valid JSON Schema Draft 4. My changes makes it a valid JSON Schema Draft 4.
