### PR TITLE
[BUGFIX]  required has to be a boolean

### DIFF
--- a/nodelist-schema-1.0.1.json
+++ b/nodelist-schema-1.0.1.json
@@ -2,7 +2,6 @@
   "$schema": "http://json-schema.org/draft-03/schema#",
   "description": "nodelistjson schema",
   "type": "object",
-  "required" : ["version"],
   "properties": {
     "version": {
       "type": "string",


### PR DESCRIPTION
Schema is not valid to draft-03.
`version` has his own `required` field.

Tested with:
- https://json-schema-validator.herokuapp.com/
- https://jsonschemalint.com/#/version/draft-03/markup/json